### PR TITLE
InStockOptionSelectBuilder - add missing required argument

### DIFF
--- a/Plugin/Model/ResourceModel/Attribute/InStockOptionSelectBuilder.php
+++ b/Plugin/Model/ResourceModel/Attribute/InStockOptionSelectBuilder.php
@@ -31,7 +31,7 @@ class InStockOptionSelectBuilder extends CoreInStockOptionSelectBuilder
         Status $stockStatusResource,
         StockConfigurationInterface $stockConfiguration
     ) {
-        parent::__construct($stockStatusResource);
+        parent::__construct($stockStatusResource, $stockConfiguration);
         $this->stockConfiguration = $stockConfiguration;
     }
 


### PR DESCRIPTION
 $stockConfig is a required argument in the parent::__construct call